### PR TITLE
feat: Added the script for raising the PR for mergeing 

### DIFF
--- a/chart-sync.sh
+++ b/chart-sync.sh
@@ -42,7 +42,7 @@ then
     PR_TITLE="Sync changes from ${INPUT_SOURCE_REPO} for release ${RELEASE_TAG}"
     PR_BODY="This pull request syncs changes from ${INPUT_SOURCE_REPO} for release ${RELEASE_TAG}."
     curl -X POST \
-    -H "Authorization: token ${GITHUB_TOKEN}" \
+    -H "Authorization: token ${INPUT_GIT_TARGET_TOKEN}" \
     -d "{\"title\":\"$PR_TITLE\",\"body\":\"$PR_BODY\",\"head\":\"$NEW_BRANCH_NAME\",\"base\":\"main\"}" \
     "https://api.github.com/repos/$INPUT_TARGET_REPO/pulls"
 

--- a/chart-sync.sh
+++ b/chart-sync.sh
@@ -1,25 +1,52 @@
-RELEASE_FILE_CONTENTS=$(curl -L -s  "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${RELEASE_BRANCH}/manifests/release.txt" )
+RELEASE_FILE_CONTENTS=$(curl -L -s "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${RELEASE_BRANCH}/manifests/release.txt")
 RELEASE_TYPE=$(echo $RELEASE_FILE_CONTENTS | awk '{print $1}')
-if [[ "$RELEASE_TYPE" == "stable" ]]
+RELEASE_TAG=$(echo $RELEASE_FILE_CONTENTS | awk '{print $3}')
+
+if [[ "$RELEASE_TYPE" == "stable" ]]; 
 then
-echo "Starting Repo sync..."
-git clone $INPUT_SOURCE_REPO
-cd ..
-git clone $INPUT_TARGET_REPO
-cd $INPUT_WORKING_DIR
-git remote add target https://${INPUT_GIT_TARGET_USERNAME}:${INPUT_GIT_TARGET_TOKEN}@${INPUT_TARGET_REPO#https://}
+    echo "Starting PR creation..."
+    # Clone the source repository
+    git clone $INPUT_SOURCE_REPO
+    cd ..
 
-git checkout main
-git remote -v
+    # Clone the target repository
+    git clone $INPUT_TARGET_REPO
+    cd $INPUT_WORKING_DIR
+    
+    # Add a remote for the target repository
+    git remote add target https://${INPUT_GIT_TARGET_USERNAME}:${INPUT_GIT_TARGET_TOKEN}@${INPUT_TARGET_REPO#https://}
+    
+    # Check out to the main branch and print remotes for verification
+    git checkout main
+    git remote -v
+    
+    # Set Git user email and name
+    git config --global user.email ${INPUT_GIT_TARGET_USEREMAIL}
+    git config --global user.name ${INPUT_GIT_TARGET_USERNAME}
+    
+    # Create a unique branch name using prefix and Git hash
+    NEW_BRANCH_NAME="sync-$(date +"%Y-%m-%d-%H%M%S")-$(git rev-parse --short HEAD)"
+    
+    # Create and checkout a new branch
+    git checkout -b $NEW_BRANCH_NAME
+    
+    # Copy contents from source directory to target directory
+    rsync -av --exclude='.git' ../${INPUT_SOURCE_DIR} $INPUT_TARGET_DIR
+    
+    # Commit the changes and push them to the new branch
+    git add .
+    git commit -m "Syncing Repo from branch ${NEW_BRANCH_NAME}"
+    git push target $NEW_BRANCH_NAME
+    
+    # Create a pull request from the new branch to the main branch
+    PR_TITLE="Sync changes from ${INPUT_SOURCE_REPO} for release ${RELEASE_TAG}"
+    PR_BODY="This pull request syncs changes from ${INPUT_SOURCE_REPO} for release ${RELEASE_TAG}."
+    curl -X POST \
+    -H "Authorization: token ${GITHUB_TOKEN}" \
+    -d "{\"title\":\"$PR_TITLE\",\"body\":\"$PR_BODY\",\"head\":\"$NEW_BRANCH_NAME\",\"base\":\"main\"}" \
+    "https://api.github.com/repos/$INPUT_TARGET_REPO/pulls"
 
-git config --global user.email ${INPUT_GIT_TARGET_USEREMAIL}
-git config --global user.name ${INPUT_GIT_TARGET_USERNAME}
-
-cp -r ../${INPUT_SOURCE_DIR} $INPUT_TARGET_DIR
-git add .
-git commit -m "Synching Repo"
-
-git push target main
+    echo "Pull request created successfully."
 else
-echo "No sync operation due to beta"
+    echo "No sync operation due to beta"
 fi


### PR DESCRIPTION
_**Problem Statement:**_ Update the release action that syncs chart to charts repo to raise a PR instead of pushing to main as the repository now has branch protection rules applied.
_**Sol:**_ I have added the script which creates a new branch whenever the action in triggered. The changes will be made on that new branch and then it uses Github API to create a pull request using the access token. 
The only change i have made in the previous code is that i have replaced cp command with rsync as i wanted to exclude .git folder (if exists) from copying  as it was causing error while copying the data from another branch other than main/master. 
Also added the tag by extracting it from the release file.